### PR TITLE
Update notionJobTracker.gs.txt

### DIFF
--- a/notionJobTracker.gs.txt
+++ b/notionJobTracker.gs.txt
@@ -1,10 +1,12 @@
-// Securely fetch credentials from Script Properties
-const NOTION_API_KEY = PropertiesService.getScriptProperties().getProperty("NOTION_API_KEY");
-const DATABASE_ID = PropertiesService.getScriptProperties().getProperty("DATABASE_ID");
+// Get API credentials from script properties
+function getNotionCredentials() {
+  const scriptProperties = PropertiesService.getScriptProperties();
+  return {
+    apiKey: scriptProperties.getProperty('NOTION_API_KEY'),
+    databaseId: scriptProperties.getProperty('DATABASE_ID')
+  };
+}
 
-/**
- * Main function: runs once with full Notion scrape, then incremental updates only.
- */
 function sendGmailJobsToNotion() {
   const isFirstRun = !PropertiesService.getScriptProperties().getProperty("initialScrapeDone");
 
@@ -20,57 +22,6 @@ function sendGmailJobsToNotion() {
   processGmailEmails();
 }
 
-/**
- * Deletes all pages in the Notion database (for initial setup only).
- */
-function clearNotionDatabase() {
-  const queryPayload = {
-    database_id: DATABASE_ID,
-    page_size: 100
-  };
-
-  const options = {
-    method: "post",
-    headers: notionHeaders(),
-    payload: JSON.stringify(queryPayload),
-    muteHttpExceptions: true
-  };
-
-  try {
-    const response = UrlFetchApp.fetch(`https://api.notion.com/v1/databases/${DATABASE_ID}/query`, options);
-    const pages = JSON.parse(response.getContentText()).results || [];
-
-    pages.forEach(page => {
-      deleteNotionPage(page.id);
-      Utilities.sleep(200);
-    });
-
-    Logger.log(`Cleared ${pages.length} pages from Notion.`);
-  } catch (error) {
-    Logger.log("Error during Notion clear: " + error.message);
-  }
-}
-
-/**
- * Deletes a specific Notion page.
- */
-function deleteNotionPage(pageId) {
-  const options = {
-    method: "delete",
-    headers: notionHeaders(),
-    muteHttpExceptions: true
-  };
-
-  try {
-    UrlFetchApp.fetch(`https://api.notion.com/v1/pages/${pageId}`, options);
-  } catch (e) {
-    Logger.log("Failed to delete Notion page: " + pageId);
-  }
-}
-
-/**
- * Processes Gmail emails to extract job applications.
- */
 function processGmailEmails() {
   const query = 'subject:(application OR interview OR "job offer" OR "thank you" OR rejected OR declined OR "follow-up" OR "follow up" OR "job opportunity" OR "position") newer_than:3m';
   const threads = GmailApp.search(query, 0, 500); // Max 500 emails
@@ -83,11 +34,7 @@ function processGmailEmails() {
 
   threads.forEach((thread, index) => {
     const threadId = thread.getId();
-
-    if (isThreadProcessed(threadId)) {
-      skippedCount++;
-      return;
-    }
+    const processedData = getProcessedThreadData(threadId);
 
     try {
       const messages = thread.getMessages();
@@ -105,18 +52,34 @@ function processGmailEmails() {
       const status = determineJobStatus(subject, body);
       const { jobTitle, company } = extractJobDetails(subject, body, from);
 
-      const success = createNotionEntry({
-        threadId, jobTitle, company, status, subject, snippet, date, emailAddress
-      });
+      Logger.log(`Processing thread ${threadId}: ${subject} | Status: ${status}`);
 
-      if (success) {
-        markThreadProcessed(threadId);
-        successCount++;
+      // Force update if the status has not changed (for debugging purposes)
+      if (processedData && processedData.pageId) {
+        if (processedData.status !== status || true) {  // Force update even if status hasn't changed
+          updateNotionStatus(processedData.pageId, status, date);
+          markThreadProcessed(threadId, processedData.pageId, status, date);
+          Logger.log(`🔁 Updated status for thread ${threadId} → ${status}`);
+          successCount++;
+        } else {
+          skippedCount++;
+          Logger.log(`Skipped thread ${threadId} as status didn't change.`);
+          return;
+        }
       } else {
-        errorCount++;
+        const pageId = createNotionEntry({
+          threadId, jobTitle, company, status, subject, snippet, date, emailAddress
+        });
+
+        if (pageId) {
+          markThreadProcessed(threadId, pageId, status, date);
+          successCount++;
+        } else {
+          errorCount++;
+        }
       }
     } catch (error) {
-      Logger.log(`Error on thread ${index}: ${error.message}`);
+      Logger.log(`❌ Error on thread ${index}: ${error.message}`);
       errorCount++;
     }
 
@@ -124,6 +87,164 @@ function processGmailEmails() {
   });
 
   Logger.log(`✔️ Done. Success: ${successCount}, Skipped: ${skippedCount}, Errors: ${errorCount}`);
+}
+
+/**
+ * Extract job title and company from email content.
+ * @param {string} subject - Email subject
+ * @param {string} body - Email body
+ * @param {string} from - Email sender
+ * @return {Object} Object containing jobTitle and company
+ */
+function extractJobDetails(subject, body, from) {
+  let jobTitle = "";
+  let company = "";
+  
+  // First, try to extract from the subject
+  // Common patterns in job application emails
+  const subjectPatterns = [
+    // "Job Title at Company"
+    /\b([\w\s\-\.\/&,]+?) at ([\w\s\-\.\/&,]+)/i,
+    // "Company: Job Title"
+    /\b([\w\s\-\.\/&,]+?):\s*([\w\s\-\.\/&,]+)/i,
+    // "Re: Job Title - Company"
+    /Re:\s*([\w\s\-\.\/&,]+?)\s*[-–]\s*([\w\s\-\.\/&,]+)/i,
+    // "Company - Job Title"
+    /([\w\s\-\.\/&,]+?)\s*[-–]\s*([\w\s\-\.\/&,]+)/i,
+    // "Company | Job Title"
+    /([\w\s\-\.\/&,]+?)\s*[|]\s*([\w\s\-\.\/&,]+)/i,
+    // "Job Application for Job Title"
+    /(?:Job Application|Application|Applied) for\s+([\w\s\-\.\/&,]+)/i,
+    // "Job Title - Application"
+    /([\w\s\-\.\/&,]+?)\s*[-–]\s*Application/i
+  ];
+
+  // Try each pattern on the subject
+  for (const pattern of subjectPatterns) {
+    const match = subject.match(pattern);
+    if (match) {
+      // Different patterns have different group positions
+      if (pattern.toString().includes("at")) {
+        jobTitle = match[1].trim();
+        company = match[2].trim();
+      } else if (pattern.toString().includes(":")) {
+        company = match[1].trim();
+        jobTitle = match[2].trim();
+      } else if (pattern.toString().includes("Application for")) {
+        jobTitle = match[1].trim();
+        // Company might be in the from field
+        company = extractCompanyFromSender(from);
+      } else if (pattern.toString().includes("[-–]\\s*Application")) {
+        jobTitle = match[1].trim();
+        company = extractCompanyFromSender(from);
+      } else {
+        // For patterns like "Company - Job Title" or "Company | Job Title"
+        company = match[1].trim();
+        jobTitle = match[2].trim();
+      }
+      break;
+    }
+  }
+
+  // If we couldn't get both from the subject, try the body
+  if (!jobTitle || !company) {
+    // Look for job title in the body if not found
+    if (!jobTitle) {
+      const titleMatch = body.match(/(?:position|job title|role|opportunity)(?:\s+is)?(?:\s+for)?:\s*([\w\s\-\.\/&,]+?)(?:\n|\.|\,|at|with)/i);
+      if (titleMatch) jobTitle = titleMatch[1].trim();
+    }
+    
+    // Look for company in the body if not found
+    if (!company) {
+      const companyMatch = body.match(/(?:at|with|from|join)\s+([\w\s\-\.\/&,]+?)(?:\n|\.|\,|\s+team|\s+for)/i);
+      if (companyMatch) company = companyMatch[1].trim();
+    }
+  }
+
+  // Last resort: extract from the sender if still missing
+  if (!company) {
+    company = extractCompanyFromSender(from);
+  }
+
+  // Clean up the results
+  jobTitle = jobTitle || "Unknown Position";
+  company = company || "Unknown Company";
+  
+  // Limit length to prevent issues
+  jobTitle = jobTitle.substring(0, 100);
+  company = company.substring(0, 100);
+  
+  // Remove common noise words from job titles
+  jobTitle = jobTitle.replace(/^(?:re:|fwd:|fw:)/i, "").trim();
+  
+  // Remove common noise from company names
+  company = company.replace(/^(?:team|careers|jobs|hr|recruiting|talent|people)/i, "").trim();
+  
+  // If company is a job platform, try to extract from elsewhere
+  if (isJobPlatform(company)) {
+    const alternateCompany = extractCompanyFromBody(body);
+    if (alternateCompany) company = alternateCompany;
+  }
+  
+  return { jobTitle, company };
+}
+
+/**
+ * Extract company name from sender's email address or name.
+ * @param {string} from - Email sender string
+ * @return {string} Extracted company name
+ */
+function extractCompanyFromSender(from) {
+  // Try to extract a company name from the sender's email
+  // First, check if there's a display name part
+  const nameMatch = from.match(/^"?([^"<]+)"?\s*(?:<.+>)?$/);
+  if (nameMatch) {
+    const displayName = nameMatch[1].trim();
+    // Check if display name contains company indicators
+    if (displayName.includes("Team") || 
+        displayName.includes("Recruiting") || 
+        displayName.includes("Careers") ||
+        displayName.includes("HR") ||
+        displayName.includes("Talent")) {
+      return displayName.replace(/team|recruiting|careers|hr|talent/i, "").trim();
+    }
+    return displayName;
+  }
+  
+  // Extract domain from email address
+  const emailMatch = from.match(/@([\w-]+)\./i);
+  if (emailMatch) {
+    // Convert domain to company name format
+    let domain = emailMatch[1];
+    if (!isJobPlatform(domain)) {
+      return domain.charAt(0).toUpperCase() + domain.slice(1);
+    }
+  }
+  
+  return "Unknown Company";
+}
+
+/**
+ * Try to extract company name from email body.
+ * @param {string} body - Email body
+ * @return {string} Extracted company name or empty string
+ */
+function extractCompanyFromBody(body) {
+  const companyPatterns = [
+    /on behalf of\s+([\w\s\-\.\/&,]+?)(?:\n|\.|\,)/i,
+    /position at\s+([\w\s\-\.\/&,]+?)(?:\n|\.|\,)/i,
+    /join\s+([\w\s\-\.\/&,]+?)(?:'s|\s+team)/i,
+    /welcome to\s+([\w\s\-\.\/&,]+?)(?:'s|\s+hiring)/i
+  ];
+  
+  for (const pattern of companyPatterns) {
+    const match = body.match(pattern);
+    if (match) {
+      return match[1].trim();
+    }
+  }
+  
+  return "";
 }
 
 /**
@@ -141,69 +262,79 @@ function determineJobStatus(subject, body) {
 }
 
 /**
- * Extract job title and company name intelligently.
+ * Check if company is a known job platform.
  */
-function extractJobDetails(subject, body, from) {
-  let jobTitle = "N/A";
-  let company = "N/A";
-
-  const companyPatterns = [
-    /(?:thank you for applying to|interview with|position at|role at|team at|opening at)\s+["']?([\w\s&-.]+?)["']?(?:['"]s|\.|,|\s|$)/i
-  ];
-
-  for (const pattern of companyPatterns) {
-    const match = body.match(pattern);
-    if (match && match[1] && !isJobPlatform(match[1])) {
-      company = cleanCompany(match[1]);
-      break;
-    }
-  }
-
-  if (company === "N/A") {
-    const fallback = subject.match(/(?:at|with)\s+["']?([\w\s&-.]+)["']?/i);
-    if (fallback && fallback[1] && !isJobPlatform(fallback[1])) {
-      company = cleanCompany(fallback[1]);
-    }
-  }
-
-  if (company === "N/A" && from) {
-    const nameMatch = from.match(/^"?([^"<@]+?)"?\s*(?:<|$)/);
-    if (nameMatch && nameMatch[1] && nameMatch[1].split(/\s+/).length > 1) {
-      company = cleanCompany(nameMatch[1]);
-    }
-    const domainMatch = from.match(/@([^.]+)\./);
-    if (company === "N/A" && domainMatch && !isCommonEmailDomain(domainMatch[1])) {
-      company = domainMatch[1].split(/[-_]/).map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
-    }
-  }
-
-  const jobPatterns = [
-    /(?:position|role|application:)\s*["']?([^"']+?)["']?\s*(?:at|with|$)/i,
-    /(.+?)\s*(?:position|role|job)\s*(?:at|with|$)/i,
-    /(.+?)\s*(?:opportunity|opening)/i
-  ];
-
-  for (const pattern of jobPatterns) {
-    const match = subject.match(pattern);
-    if (match && match[1]) {
-      jobTitle = match[1].replace(/^(Re:|Fwd:)\s*/i, '').trim();
-      break;
-    }
-  }
-
-  return { jobTitle, company };
+function isJobPlatform(name) {
+  if (!name) return true;
+  const platforms = ['linkedin', 'indeed', 'glassdoor', 'ziprecruiter', 'monster', 'lever', 'workday', 'greenhouse', 'angellist', 'smartrecruiters', 'taleo', 'careerbuilder', 'wellfound'];
+  return platforms.some(p => name.toLowerCase().includes(p));
 }
 
-function cleanCompany(name) {
-  return name.replace(/\s+(Inc|LLC|Ltd|Corp|Co|Limited)\.?$/i, '').trim();
+function notionHeaders() {
+  const credentials = getNotionCredentials();
+  return {
+    "Authorization": `Bearer ${credentials.apiKey}`,
+    "Content-Type": "application/json",
+    "Notion-Version": "2022-06-28"
+  };
+}
+
+/**
+ * Update status for Notion page.
+ */
+function updateNotionStatus(pageId, newStatus, newDate) {
+  if (!pageId) {
+    Logger.log("Error: Attempted to update Notion page with undefined pageId");
+    return;
+  }
+  
+  const payload = {
+    properties: {
+      "Status": { select: { name: newStatus } },
+      "Date": { date: { start: newDate.toISOString() } }
+    }
+  };
+
+  const options = {
+    method: "patch",
+    headers: notionHeaders(),
+    payload: JSON.stringify(payload),
+    muteHttpExceptions: true
+  };
+
+  try {
+    const response = UrlFetchApp.fetch(`https://api.notion.com/v1/pages/${pageId}`, options);
+    const code = response.getResponseCode();
+    if (code >= 400) {
+      Logger.log("Failed to update Notion status: " + response.getContentText());
+    } else {
+      Logger.log(`Updated Notion page: ${pageId}`);
+    }
+  } catch (e) {
+    Logger.log("Error updating Notion page: " + e.message);
+  }
+}
+
+/**
+ * Track processed thread IDs to avoid duplicates.
+ */
+function getProcessedThreadData(threadId) {
+  const json = PropertiesService.getScriptProperties().getProperty(`thread_${threadId}`);
+  return json ? JSON.parse(json) : null;
+}
+
+function markThreadProcessed(threadId, notionPageId, status, date) {
+  const data = { pageId: notionPageId, status: status, date: date };
+  PropertiesService.getScriptProperties().setProperty(`thread_${threadId}`, JSON.stringify(data));
 }
 
 /**
  * Create a Notion entry.
  */
 function createNotionEntry(data) {
+  const credentials = getNotionCredentials();
   const payload = {
-    parent: { database_id: DATABASE_ID },
+    parent: { database_id: credentials.databaseId },
     properties: {
       "Company": { title: [{ text: { content: data.company } }] },
       "Job Title": { rich_text: [{ text: { content: data.jobTitle } }] },
@@ -227,58 +358,41 @@ function createNotionEntry(data) {
     const code = response.getResponseCode();
     if (code >= 400) {
       Logger.log("Error creating Notion entry: " + response.getContentText());
-      return false;
+      return null;
     }
-    return true;
+    const responseData = JSON.parse(response.getContentText());
+    return responseData.id; // ✅ Return Notion page ID
   } catch (e) {
     Logger.log("Error posting to Notion: " + e.message);
-    return false;
+    return null;
   }
 }
 
 /**
- * Get standard Notion API headers.
+ * Clears the Notion database (use with caution).
  */
-function notionHeaders() {
-  return {
-    "Authorization": `Bearer ${NOTION_API_KEY}`,
-    "Content-Type": "application/json",
-    "Notion-Version": "2022-06-28"
+function clearNotionDatabase() {
+  const credentials = getNotionCredentials();
+  const options = {
+    method: 'get',
+    headers: notionHeaders()
   };
-}
-
-/**
- * Check if company is a known job platform.
- */
-function isJobPlatform(name) {
-  if (!name) return true;
-  const platforms = ['linkedin', 'indeed', 'glassdoor', 'ziprecruiter', 'monster', 'lever', 'workday', 'greenhouse', 'angellist', 'smartrecruiters', 'taleo', 'careerbuilder', 'wellfound'];
-  return platforms.some(p => name.toLowerCase().includes(p));
-}
-
-/**
- * Check if email domain is generic.
- */
-function isCommonEmailDomain(domain) {
-  return ['gmail', 'yahoo', 'outlook', 'hotmail', 'aol', 'icloud', 'protonmail'].includes(domain.toLowerCase());
-}
-
-/**
- * Track processed thread IDs to avoid duplicates.
- */
-function isThreadProcessed(threadId) {
-  return PropertiesService.getScriptProperties().getProperty(`thread_${threadId}`) === "true";
-}
-
-function markThreadProcessed(threadId) {
-  PropertiesService.getScriptProperties().setProperty(`thread_${threadId}`, "true");
-}
-
-/**
- * Create a daily trigger (optional setup)
- */
-function createDailyTrigger() {
-  ScriptApp.getProjectTriggers().forEach(t => ScriptApp.deleteTrigger(t));
-  ScriptApp.newTrigger("sendGmailJobsToNotion").timeBased().everyDays(1).atHour(6).create();
-  Logger.log("📅 Daily trigger set at 6 AM.");
+  
+  try {
+    const response = UrlFetchApp.fetch(`https://api.notion.com/v1/databases/${credentials.databaseId}/query`, options);
+    const data = JSON.parse(response.getContentText());
+    const ids = data.results.map(result => result.id);
+    
+    ids.forEach(id => {
+      const deleteOptions = {
+        method: 'delete',
+        headers: notionHeaders()
+      };
+      
+      UrlFetchApp.fetch(`https://api.notion.com/v1/pages/${id}`, deleteOptions);
+      Logger.log(`Deleted page: ${id}`);
+    });
+  } catch (e) {
+    Logger.log("Error clearing Notion database: " + e.message);
+  }
 }


### PR DESCRIPTION
feat: Add full Gmail-to-Notion job tracker with improved parsing and Notion syncing

- Implemented Gmail search and filtering for job-related emails
- Extracted job title and company from email subject, body, and sender
- Integrated Notion API to create and update entries with job details
- Added support for status updates (Applied, Interview, Offer, Rejected, Followup)
- Included deduplication logic using Script Properties
- Improved error handling and logging for debugging
- Included function to clear Notion database on first run
- Added utilities to extract company names from various patterns
- Supports Google Apps Script trigger via `sendGmailJobsToNotion()`

This patch significantly improves automation of job application tracking from Gmail to Notion.
